### PR TITLE
Use builtin libjpeg for Linux wxWidgets

### DIFF
--- a/.github/workflows/build-browser.yml
+++ b/.github/workflows/build-browser.yml
@@ -113,7 +113,7 @@ jobs:
 
           mkdir gtk-build
           cd gtk-build
-          ../configure --with-opengl --disable-shared
+          ../configure --with-opengl --disable-shared --with-libjpeg=builtin
           make -j$(nproc)
           sudo make install
           sudo ldconfig


### PR DESCRIPTION
I tested this on Fedora, and it won't open. The only missing dependency is `libjpeg.so.8`, which is not available on Fedora. It appears that wxWidgets has an option to compile libjpeg itself, rather than rely on the system library.

This should make the program usable on Red Hat/Fedora Linux variants.